### PR TITLE
Update rdmty Header to show more accurate data

### DIFF
--- a/app/rdmty.js
+++ b/app/rdmty.js
@@ -1,510 +1,712 @@
+'use strict';
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
 // fiddle: http://jsfiddle.net/v1ddnsvh/8/
 /* global window */
-
+// If you need a handy tool to transpile your JSX: https://babeljs.io/repl/#?babili=false&evaluate=true&lineWrap=false&presets=es2015%2Creact%2Cstage-2&targets=&browsers=&builtIns=false&debug=false&code_lz=Q
 var IMAGE_PATH = 'images';
 var EncountersArray = [];
 
 var React = window.React;
 
-var formatNumber = function(number)  {
+var formatNumber = function formatNumber(number) {
     number = parseFloat(number, 10);
 
     if (number >= 1000) {
         return (number / 1000).toFixed(2) + 'K';
-    }
-    else if (number >= 1000000) {
-        return (number / 1000000).toFixed(2) + 'K';
+    } else if (number >= 1000000) {
+        return (number / 1000000).toFixed(2) + 'M';
     }
 
     return number.toFixed(2);
 };
-var ____Class0=React.Component;for(var ____Class0____Key in ____Class0){if(____Class0.hasOwnProperty(____Class0____Key)){CombatantCompact[____Class0____Key]=____Class0[____Class0____Key];}}var ____SuperProtoOf____Class0=____Class0===null?null:____Class0.prototype;CombatantCompact.prototype=Object.create(____SuperProtoOf____Class0);CombatantCompact.prototype.constructor=CombatantCompact;CombatantCompact.__superConstructor__=____Class0;function CombatantCompact(){"use strict";if(____Class0!==null){____Class0.apply(this,arguments);}}
-    Object.defineProperty(CombatantCompact.prototype,"jobImage",{writable:true,configurable:true,value:function(job) {"use strict";
-        if (window.JSFIDDLE) {
-            return window.GLOW_ICONS[job.toLowerCase()];
+
+var CombatantCompact = function (_React$Component) {
+    _inherits(CombatantCompact, _React$Component);
+
+    function CombatantCompact() {
+        _classCallCheck(this, CombatantCompact);
+
+        return _possibleConstructorReturn(this, (CombatantCompact.__proto__ || Object.getPrototypeOf(CombatantCompact)).apply(this, arguments));
+    }
+
+    _createClass(CombatantCompact, [{
+        key: 'jobImage',
+        value: function jobImage(job) {
+            if (window.JSFIDDLE) {
+                return window.GLOW_ICONS[job.toLowerCase()];
+            }
+
+            return IMAGE_PATH + '/default/' + job.toLowerCase() + '.png';
         }
+    }, {
+        key: 'render',
+        value: function render() {
+            //var width = parseInt(this.props.data.damage / this.props.encounterDamage * 100, 10) + '%';
+            var width = Math.min(100, parseInt(this.props.total / this.props.max * 100, 10)) + '%';
 
-        return IMAGE_PATH + '/default/' + job.toLowerCase() + '.png';
-    }});
-
-    Object.defineProperty(CombatantCompact.prototype,"render",{writable:true,configurable:true,value:function() {"use strict";
-        //var width = parseInt(this.props.data.damage / this.props.encounterDamage * 100, 10) + '%';
-        var width = Math.min(100, parseInt(this.props.total / this.props.max * 100, 10)) + '%';
-        return (
-            this.props.perSecond === '---' ? null :
-            React.createElement("li", {
-                className: 'row ' + this.props.job.toLowerCase() + (this.props.isSelf ? ' self' : ''), 
-                onClick: this.props.onClick}, 
-                React.createElement("div", {
-                    className: "bar", 
-                    style: {width: width}}), 
-                    React.createElement("div", {className: "text-overlay"}, 
-                        React.createElement("div", {className: "stats"}, 
-                            React.createElement("span", {className: "total"}, 
-                                this.props.totalFormatted
-                            ), 
-
-                            this.props.additional ?
-                            React.createElement("span", {className: "additional"}, 
-                                "[", this.props.additional, "]"
-                            ) : null, 
-
-
-                            "(", 
-                            React.createElement("span", {className: "ps"}, 
-                                this.props.perSecond, ","
-                            ), 
-
-                            React.createElement("span", {className: "percent"}, 
-                                this.props.percentage
-                            ), 
-                            ")"
-                        ), 
-                        React.createElement("div", {className: "info"}, 
-                            React.createElement("span", {className: "job-icon"}, 
-                                React.createElement("img", {src: this.jobImage(this.props.job)})
-                            ), 
-                            React.createElement("span", {className: "rank"}, 
-                                this.props.rank, "."
-                            ), 
-                            React.createElement("span", {className: "character-name"}, 
-                                this.props.characterName
-                            ), 
-                            React.createElement("span", {className: "character-job"}, 
-                                this.props.job
-                            )
+            return this.props.perSecond === '---' ? null : React.createElement(
+                'li',
+                {
+                    className: 'row ' + this.props.job.toLowerCase() + (this.props.isSelf ? ' self' : ''),
+                    onClick: this.props.onClick },
+                React.createElement('div', {
+                    className: 'bar',
+                    style: { width: width } }),
+                React.createElement(
+                    'div',
+                    { className: 'text-overlay' },
+                    React.createElement(
+                        'div',
+                        { className: 'stats' },
+                        React.createElement(
+                            'span',
+                            { className: 'total' },
+                            this.props.totalFormatted
+                        ),
+                        this.props.additional ? React.createElement(
+                            'span',
+                            { className: 'additional' },
+                            '[',
+                            this.props.additional,
+                            ']'
+                        ) : null,
+                        '(',
+                        React.createElement(
+                            'span',
+                            { className: 'ps' },
+                            this.props.perSecond,
+                            ','
+                        ),
+                        React.createElement(
+                            'span',
+                            { className: 'percent' },
+                            this.props.percentage
+                        ),
+                        ')'
+                    ),
+                    React.createElement(
+                        'div',
+                        { className: 'info' },
+                        React.createElement(
+                            'span',
+                            { className: 'job-icon' },
+                            React.createElement('img', { src: this.jobImage(this.props.job) })
+                        ),
+                        React.createElement(
+                            'span',
+                            { className: 'rank' },
+                            this.props.rank,
+                            '.'
+                        ),
+                        React.createElement(
+                            'span',
+                            { className: 'character-name' },
+                            this.props.characterName
+                        ),
+                        React.createElement(
+                            'span',
+                            { className: 'character-job' },
+                            this.props.job
                         )
                     )
-            )
-        );
-    }});
+                )
+            );
+        }
+    }]);
+
+    return CombatantCompact;
+}(React.Component);
 
 CombatantCompact.defaultProps = {
-    onClick:function() {}
+    onClick: function onClick() {}
 };
 
-var ____Class1=React.Component;for(var ____Class1____Key in ____Class1){if(____Class1.hasOwnProperty(____Class1____Key)){ChartView[____Class1____Key]=____Class1[____Class1____Key];}}var ____SuperProtoOf____Class1=____Class1===null?null:____Class1.prototype;ChartView.prototype=Object.create(____SuperProtoOf____Class1);ChartView.prototype.constructor=ChartView;ChartView.__superConstructor__=____Class1;function ChartView(){"use strict";if(____Class1!==null){____Class1.apply(this,arguments);}}
-    Object.defineProperty(ChartView.prototype,"render",{writable:true,configurable:true,value:function() {"use strict";
-        return (
-            React.createElement("div", {className: "chart-view"}
-            )
-        );
-    }});
+var ChartView = function (_React$Component2) {
+    _inherits(ChartView, _React$Component2);
 
+    function ChartView() {
+        _classCallCheck(this, ChartView);
 
-var ____Class2=React.Component;for(var ____Class2____Key in ____Class2){if(____Class2.hasOwnProperty(____Class2____Key)){Header[____Class2____Key]=____Class2[____Class2____Key];}}var ____SuperProtoOf____Class2=____Class2===null?null:____Class2.prototype;Header.prototype=Object.create(____SuperProtoOf____Class2);Header.prototype.constructor=Header;Header.__superConstructor__=____Class2;
-    function Header(props) {"use strict";
-        ____Class2.call(this,props);
-        this.state = {
+        return _possibleConstructorReturn(this, (ChartView.__proto__ || Object.getPrototypeOf(ChartView)).apply(this, arguments));
+    }
+
+    _createClass(ChartView, [{
+        key: 'render',
+        value: function render() {
+            return React.createElement('div', { className: 'chart-view' });
+        }
+    }]);
+
+    return ChartView;
+}(React.Component);
+
+var Header = function (_React$Component3) {
+    _inherits(Header, _React$Component3);
+
+    function Header(props) {
+        _classCallCheck(this, Header);
+
+        var _this3 = _possibleConstructorReturn(this, (Header.__proto__ || Object.getPrototypeOf(Header)).call(this, props));
+
+        _this3.state = {
             expanded: false,
             showEncountersList: false
         };
+        return _this3;
     }
 
-    Object.defineProperty(Header.prototype,"shouldComponentUpdate",{writable:true,configurable:true,value:function(nextProps) {"use strict";
-        if (nextProps.encounter.encdps === '---') {
-            return false;
+    _createClass(Header, [{
+        key: 'shouldComponentUpdate',
+        value: function shouldComponentUpdate(nextProps) {
+            // WIll need to add a null check here if we are swapping betwen self and group.
+            // Possibly more null checks as well.
+            if (nextProps.encounter.encdps === '---') {
+                return false;
+            }
+            return true;
+        }
+    }, {
+        key: 'handleExtraDetails',
+        value: function handleExtraDetails(e) {
+            this.props.onExtraDetailsClick(e);
+
+            this.setState({
+                expanded: !this.state.expanded
+            });
         }
 
-        return true;
-    }});
+        /**
+         * Show dropdown for list of encounters
+         */
 
-    Object.defineProperty(Header.prototype,"handleExtraDetails",{writable:true,configurable:true,value:function(e) {"use strict";
-        this.props.onExtraDetailsClick(e);
-
-        this.setState({
-            expanded: !this.state.expanded
-        });
-    }});
-
-    /**
-     * Show dropdown for list of encounters
-     */
-    Object.defineProperty(Header.prototype,"handleEncounterClick",{writable:true,configurable:true,value:function(e) {"use strict";
-        this.setState({
-            showEncountersList: !this.state.showEncountersList
-        });
-    }});
-
-    Object.defineProperty(Header.prototype,"render",{writable:true,configurable:true,value:function() {"use strict";
-        var encounter = this.props.encounter;
-        var self = this.props.data['YOU'];
-        var rdps = parseFloat(encounter.encdps);
-        var rdps_max = 0;
-
-        if (!isNaN(rdps) && rdps !== Infinity) {
-            rdps_max = Math.max(rdps_max, rdps);
+    }, {
+        key: 'handleEncounterClick',
+        value: function handleEncounterClick(e) {
+            this.setState({
+                showEncountersList: !this.state.showEncountersList
+            });
         }
+    }, {
+        key: 'render',
+        value: function render() {
+            var encounter = this.props.encounter;
+            var rdps = parseFloat(encounter.encdps);
+            var rdps_max = 0;
 
-        return (
-            React.createElement("div", {className: ("header " + (this.state.expanded ? '' : 'collapsed'))}, 
-                React.createElement("div", {className: "encounter-header"}, 
-                    React.createElement("div", {className: "encounter-data ff-header"}, 
-                        React.createElement("span", {className: "target-name dropdown-parent", onClick: this.handleEncounterClick.bind(this)}, 
-                            encounter.title, 
-                            React.createElement("div", {className: ("dropdown-menu encounters-list-dropdown " + (this.state.showEncountersList ? '' : 'hidden'))}, 
-                                React.createElement("div", {onClick: this.props.onSelectEncounter.bind(this, null)}, 
-                                    "Current Fight"
-                                ), 
+            if (!isNaN(rdps) && rdps !== Infinity) {
+                rdps_max = Math.max(rdps_max, rdps);
+            }
 
-                                EncountersArray.map(function(encounter, i) {
-                                    return (
-                                        React.createElement("div", {key: i, onClick: this.props.onSelectEncounter.bind(this, i)}, 
-                                            encounter.Encounter.title
-                                        )
+            // Calculate the drect hit % based off of the combatant list. This is not efficient and needs to be removed
+            // Once the encounter object is fixed to properly include this info.
+            var data = this.props.data;
+            var datalength = 0;
+            var DirectHitPct = 0;
+            var CritDirectHitPct = 0;
+
+            for (var x in data) {
+                if (!data.hasOwnProperty(x)) continue;
+                DirectHitPct += parseFloat(data[x].DirectHitPct.substring(0, data[x].DirectHitPct.length - 1));
+                CritDirectHitPct += parseFloat(data[x].CritDirectHitPct.substring(0, data[x].CritDirectHitPct.length - 1));
+                datalength++;
+            }
+
+            DirectHitPct = parseFloat(DirectHitPct / datalength);
+            CritDirectHitPct = parseFloat(CritDirectHitPct / datalength);
+
+            return React.createElement(
+                'div',
+                { className: 'header ' + (this.state.expanded ? '' : 'collapsed') },
+                React.createElement(
+                    'div',
+                    { className: 'encounter-header' },
+                    React.createElement(
+                        'div',
+                        { className: 'encounter-data ff-header' },
+                        React.createElement(
+                            'span',
+                            { className: 'target-name dropdown-parent', onClick: this.handleEncounterClick.bind(this) },
+                            encounter.title,
+                            React.createElement(
+                                'div',
+                                { className: 'dropdown-menu encounters-list-dropdown ' + (this.state.showEncountersList ? '' : 'hidden') },
+                                React.createElement(
+                                    'div',
+                                    { onClick: this.props.onSelectEncounter.bind(this, null) },
+                                    'Current Fight'
+                                ),
+                                EncountersArray.map(function (encounter, i) {
+                                    return React.createElement(
+                                        'div',
+                                        { key: i, onClick: this.props.onSelectEncounter.bind(this, i) },
+                                        encounter.Encounter.title
                                     );
-
                                 }.bind(this))
                             )
-                        ), 
-                        React.createElement("span", {className: "duration"}, 
-                            "(", encounter.duration, ")"
-                        ), 
-                        React.createElement("span", {className: ("arrow " + (this.state.expanded ? 'up' : 'down')), onClick: this.handleExtraDetails.bind(this)})
-                    ), 
-
-                    React.createElement("div", {
-                        className: "chart-view-switcher", 
-                        onClick: this.props.onViewChange}, 
+                        ),
+                        React.createElement(
+                            'span',
+                            { className: 'duration' },
+                            '(',
+                            encounter.duration,
+                            ')'
+                        ),
+                        React.createElement('span', { className: 'arrow ' + (this.state.expanded ? 'up' : 'down'), onClick: this.handleExtraDetails.bind(this) })
+                    ),
+                    React.createElement(
+                        'div',
+                        {
+                            className: 'chart-view-switcher',
+                            onClick: this.props.onViewChange },
                         this.props.currentView
                     )
-                ), 
-                React.createElement("div", {className: "extra-details"}, 
-                    React.createElement("div", {className: "extra-row damage"}, 
-                        React.createElement("div", {className: "cell"}, 
-                            React.createElement("span", {className: "label ff-header"}, "Damage"), 
-                            React.createElement("span", {className: "value ff-text"}, 
-                                formatNumber(encounter.damage) + " (" + formatNumber(encounter.encdps) + ")"
-                            )
-                        ), 
-                        /* Removing to save space
-                        React.createElement("div", {className: "cell"}, 
-                            React.createElement("span", {className: "label ff-header"}, "DPS"), 
-                            React.createElement("span", {className: "value ff-text"}, 
-                                formatNumber(encounter.encdps)
-                            )
-                        ), 
-                        */
-                        React.createElement("div", {className: "cell"}, 
-                            React.createElement("span", {className: "label ff-header"}, "Max"),
-                            React.createElement("span", {className: "value ff-text"}, 
-                                self['maxhit']
-                            )
-                            )
-                        ), 
-
-                    React.createElement("div", {className: "extra-row damage2"},
-
-                        React.createElement("div", {className: "cell"}, 
-                            React.createElement("span", {className: "label ff-header"}, "Crit"),
-                            React.createElement("span", {className: "value ff-text"}, 
-                                self['crithit%']
-                            )
-                        ), 
-                        React.createElement("div", {className: "cell"}, 
-                            React.createElement("span", {className: "label ff-header"}, "dHit"),
-                            React.createElement("span", {className: "value ff-text"},
-                                self['DirectHitPct']
+                ),
+                React.createElement(
+                    'div',
+                    { className: 'extra-details' },
+                    React.createElement(
+                        'div',
+                        { className: 'extra-row damage' },
+                        React.createElement(
+                            'div',
+                            { className: 'cell' },
+                            React.createElement(
+                                'span',
+                                { className: 'label ff-header' },
+                                'Damage'
+                            ),
+                            React.createElement(
+                                'span',
+                                { className: 'value ff-text' },
+                                formatNumber(encounter.damage) + ' (' + formatNumber(encounter.encdps) + ')'
                             )
                         ),
-                        React.createElement("div", {className: "cell"},
-                            React.createElement("span", {className: "label ff-header"}, "dCrit"),
-                            React.createElement("span", {className: "value ff-text"},
-                                self['CritDirectHitPct']
-                            )
-                        ),
-                        React.createElement("div", {className: "cell"},
-                            React.createElement("span", {className: "label ff-header"}, "Miss"),
-                            React.createElement("span", {className: "value ff-text"}, 
-                                (Math.round(self['misses']/self['swings'] * 100) || 0) + '%'
+                        React.createElement(
+                            'div',
+                            { className: 'cell' },
+                            React.createElement(
+                                'span',
+                                { className: 'label ff-header' },
+                                'Max'
+                            ),
+                            React.createElement(
+                                'span',
+                                { className: 'value ff-text' },
+                                encounter.maxhit
                             )
                         )
-                    ), 
-
-                    React.createElement("div", {className: "extra-row healing"}, 
-                        React.createElement("div", {className: "cell"}, 
-                            React.createElement("span", {className: "label ff-header"}, "Heals"), 
-                            React.createElement("span", {className: "value ff-text"}, 
-                                formatNumber(self['healed'])
+                    ),
+                    React.createElement(
+                        'div',
+                        { className: 'extra-row damage' },
+                        React.createElement(
+                            'div',
+                            { className: 'cell' },
+                            React.createElement(
+                                'span',
+                                { className: 'label ff-header' },
+                                'Crit%'
+                            ),
+                            React.createElement(
+                                'span',
+                                { className: 'value ff-text' },
+                                formatNumber(parseFloat(encounter.crithits / encounter.hits * 100)) + "%"
                             )
-                        ), 
-                        React.createElement("div", {className: "cell"}, 
-                            React.createElement("span", {className: "label ff-header"}, "HPS"), 
-                            React.createElement("span", {className: "value ff-text"}, 
-                                formatNumber(self['enchps'])
+                        ),
+                        React.createElement(
+                            'div',
+                            { className: 'cell' },
+                            React.createElement(
+                                'span',
+                                { className: 'label ff-header' },
+                                'Misses'
+                            ),
+                            React.createElement(
+                                'span',
+                                { className: 'value ff-text' },
+                                encounter.misses
                             )
-                        ), 
-                        React.createElement("div", {className: "cell"}, 
-                            React.createElement("span", {className: "label ff-header"}, "hCrit"),
-                            React.createElement("span", {className: "value ff-text"}, 
-                                self['critheal%']
+                        ),
+                        React.createElement(
+                            'div',
+                            { className: 'cell' },
+                            React.createElement(
+                                'span',
+                                { className: 'label ff-header' },
+                                'Direct%'
+                            ),
+                            React.createElement(
+                                'span',
+                                { className: 'value ff-text' },
+                                formatNumber(DirectHitPct) + "%"
                             )
-                        ), 
-                        React.createElement("div", {className: "cell"}, 
-                            React.createElement("span", {className: "label ff-header"}, "hMax"),
-                            React.createElement("span", {className: "value ff-text"}, 
-                                self['maxheal']
+                        ),
+                        React.createElement(
+                            'div',
+                            { className: 'cell' },
+                            React.createElement(
+                                'span',
+                                { className: 'label ff-header' },
+                                'DirectCrit%'
+                            ),
+                            React.createElement(
+                                'span',
+                                { className: 'value ff-text' },
+                                formatNumber(CritDirectHitPct) + "%"
+                            )
+                        )
+                    ),
+                    React.createElement(
+                        'div',
+                        { className: 'extra-row healing' },
+                        React.createElement(
+                            'div',
+                            { className: 'cell' },
+                            React.createElement(
+                                'span',
+                                { className: 'label ff-header' },
+                                'Heals'
+                            ),
+                            React.createElement(
+                                'span',
+                                { className: 'value ff-text' },
+                                formatNumber(encounter.healed) + ' (' + formatNumber(encounter.enchps) + ')'
+                            )
+                        ),
+                        React.createElement(
+                            'div',
+                            { className: 'cell' },
+                            React.createElement(
+                                'span',
+                                { className: 'label ff-header' },
+                                'Max'
+                            ),
+                            React.createElement(
+                                'span',
+                                { className: 'value ff-text' },
+                                encounter.maxheal
                             )
                         )
                     )
                 )
-            )
-        );
-    }});
+            );
+        }
+    }]);
 
+    return Header;
+}(React.Component);
 
 Header.defaultProps = {
     encounter: {},
-    onViewChange:function() {},
-    onSelectEncounter:function() {},
-    onExtraDetailsClick:function() {}
+    onViewChange: function onViewChange() {},
+    onSelectEncounter: function onSelectEncounter() {},
+    onExtraDetailsClick: function onExtraDetailsClick() {}
 };
 
+var Combatants = function (_React$Component4) {
+    _inherits(Combatants, _React$Component4);
 
-var ____Class3=React.Component;for(var ____Class3____Key in ____Class3){if(____Class3.hasOwnProperty(____Class3____Key)){Combatants[____Class3____Key]=____Class3[____Class3____Key];}}var ____SuperProtoOf____Class3=____Class3===null?null:____Class3.prototype;Combatants.prototype=Object.create(____SuperProtoOf____Class3);Combatants.prototype.constructor=Combatants;Combatants.__superConstructor__=____Class3;function Combatants(){"use strict";if(____Class3!==null){____Class3.apply(this,arguments);}}
-    Object.defineProperty(Combatants.prototype,"shouldComponentUpdate",{writable:true,configurable:true,value:function(nextProps) {"use strict";
-        // if data is empty then don't re-render
-        if (Object.getOwnPropertyNames(nextProps.data).length === 0) {
-            return false;
-        }
+    function Combatants() {
+        _classCallCheck(this, Combatants);
 
-        return true;
-    }});
-
-    Object.defineProperty(Combatants.prototype,"render",{writable:true,configurable:true,value:function() {"use strict";
-        var rows = [];
-        var maxRows = 12;
-        var isDataArray = _.isArray(this.props.data);
-        var dataArray = isDataArray ? this.props.data : Object.keys(this.props.data);
-        var limit = Math.max(dataArray.length, maxRows);
-        var names = dataArray.slice(0, maxRows-1);
-        var maxdps = false;
-        var combatant;
-        var row;
-        var isSelf;
-        var rank = 1;
-        var stats;
-
-        for (var i = 0; i < names.length; i++) {
-            combatant = isDataArray ? this.props.data[i] : this.props.data[names[i]];
-            stats = null;
-
-            isSelf = combatant.name === 'YOU' || combatant.name === 'You';
-
-            if (combatant.Job !== "") {
-                // should probably fix this
-                if (this.props.currentView === 'Healing') {
-                    if (parseInt(combatant.healed, 10) > 0) {
-                        if (!maxdps) {
-                            maxdps = parseFloat(combatant.healed);
-                        }
-                        stats = {
-                            job: combatant.Job || '',
-                            characterName: combatant.name,
-                            total: combatant.healed,
-                            totalFormatted: formatNumber(combatant.healed),
-                            perSecond: formatNumber(combatant.enchps),
-                            additional: combatant['OverHealPct'],
-                            percentage: combatant['healed%']
-                        }
-                    }
-                }
-                else if (this.props.currentView === 'Tanking') {
-                    if (parseInt(combatant.damagetaken, 10) > 0) {
-                        if (!maxdps) {
-                            maxdps = parseFloat(combatant.damagetaken);
-                        }
-                        stats = {
-                            job: combatant.Job || '',
-                            characterName: combatant.name,
-                            total: combatant.damagetaken,
-                            totalFormatted: formatNumber(combatant.damagetaken),
-                            perSecond: combatant.ParryPct,
-                            percentage: combatant.BlockPct
-                        }
-                    }
-                }
-                else {
-                    if (!maxdps) {
-                        maxdps = parseFloat(combatant.damage);
-                    }
-                    stats = {
-                        job: combatant.Job || '',
-                        characterName: combatant.name,
-                        total: combatant.damage,
-                        totalFormatted: formatNumber(combatant.damage),
-                        perSecond: formatNumber(combatant.encdps),
-                        percentage: combatant['damage%']
-                    }
-                }
-
-                if (stats) {
-                    rows.push(
-                        React.createElement(CombatantCompact, React.__spread({
-                            onClick: this.props.onClick, 
-                            encounterDamage: this.props.encounterDamage, 
-                            rank: rank, 
-                            data: combatant, 
-                            isSelf: isSelf, 
-                            key: combatant.name, 
-                            max: maxdps}, 
-                            stats)
-                        )
-                    );
-                    rank++;
-                }
-            }
-
-        }
-
-        return (
-            React.createElement("ul", {className: "combatants"}, 
-                rows
-            )
-        );
-    }});
-
-
-Combatants.defaultProps = {
-    onClick:function() {}
-};
-
-var ____Class4=React.Component;for(var ____Class4____Key in ____Class4){if(____Class4.hasOwnProperty(____Class4____Key)){DamageMeter[____Class4____Key]=____Class4[____Class4____Key];}}var ____SuperProtoOf____Class4=____Class4===null?null:____Class4.prototype;DamageMeter.prototype=Object.create(____SuperProtoOf____Class4);DamageMeter.prototype.constructor=DamageMeter;DamageMeter.__superConstructor__=____Class4;
-    function DamageMeter(props) {"use strict";
-        ____Class4.call(this,props);
-        this.state = {
-            currentViewIndex: 0
-        };
+        return _possibleConstructorReturn(this, (Combatants.__proto__ || Object.getPrototypeOf(Combatants)).apply(this, arguments));
     }
 
-    Object.defineProperty(DamageMeter.prototype,"shouldComponentUpdate",{writable:true,configurable:true,value:function(nextProps, nextState) {"use strict";
-        if (nextProps.parseData.Encounter.encdps === '---') {
-            return false;
-        }
+    _createClass(Combatants, [{
+        key: 'shouldComponentUpdate',
+        value: function shouldComponentUpdate(nextProps) {
+            // if data is empty then don't re-render
+            if (Object.getOwnPropertyNames(nextProps.data).length === 0) {
+                return false;
+            }
 
-        if (this.state.currentViewIndex !== nextState.currentViewIndex) {
             return true;
         }
+    }, {
+        key: 'render',
+        value: function render() {
+            var rows = [];
+            var maxRows = 12;
+            var isDataArray = _.isArray(this.props.data);
+            var dataArray = isDataArray ? this.props.data : Object.keys(this.props.data);
+            var limit = Math.max(dataArray.length, maxRows);
+            var names = dataArray.slice(0, maxRows - 1);
+            var maxdps = false;
+            var combatant;
+            var row;
+            var isSelf;
+            var rank = 1;
+            var stats;
 
-        if (this.state.selectedEncounter) {
-            return false;
-        }
+            for (var i = 0; i < names.length; i++) {
+                combatant = isDataArray ? this.props.data[i] : this.props.data[names[i]];
+                stats = null;
 
-        return true;
-    }});
+                isSelf = combatant.name === 'YOU' || combatant.name === 'You';
 
-    Object.defineProperty(DamageMeter.prototype,"componentWillReceiveProps",{writable:true,configurable:true,value:function(nextProps) {"use strict";
-        // save this encounter data
-        if (this.props.parseData.Encounter.title === 'Encounter' &&
-            nextProps.parseData.Encounter.title !== 'Encounter') {
-            EncountersArray.unshift({
-                Encounter: nextProps.parseData.Encounter,
-                Combatant: nextProps.parseData.Combatant
-            });
-
-            // Only keep the last 10 fights
-            if (EncountersArray.length > 10) {
-                EncountersArray.pop();
-            }
-        }
-    }});
-
-    Object.defineProperty(DamageMeter.prototype,"handleCombatRowClick",{writable:true,configurable:true,value:function(e) {"use strict";
-    }});
-
-    Object.defineProperty(DamageMeter.prototype,"handleClick",{writable:true,configurable:true,value:function(e) {"use strict";
-    }});
-
-    Object.defineProperty(DamageMeter.prototype,"handleViewChange",{writable:true,configurable:true,value:function(e) {"use strict";
-        var index = this.state.currentViewIndex;
-
-        if (index > this.props.chartViews.length-2) {
-            index = 0;
-        }
-        else {
-            index++;
-        }
-
-        this.setState({
-            currentViewIndex: index
-        });
-
-    }});
-
-    Object.defineProperty(DamageMeter.prototype,"handleSelectEncounter",{writable:true,configurable:true,value:function(index, e) {"use strict";
-        if (index >= 0) {
-            this.setState({
-                selectedEncounter: EncountersArray[index]
-            });
-        }
-        else {
-            this.setState({
-                selectedEncounter: null
-            });
-        }
-        this.render();
-        //console.log('handle select', index);
-    }});
-
-    Object.defineProperty(DamageMeter.prototype,"render",{writable:true,configurable:true,value:function() {"use strict";
-        var data = this.props.parseData.Combatant;
-        var encounterData = this.props.parseData.Encounter;
-
-        if (this.state.selectedEncounter) {
-            data = this.state.selectedEncounter.Combatant;
-            encounterData = this.state.selectedEncounter.Encounter;
-        }
-        else {
-            // Healing
-            // need to resort data if currentView is not damage
-            if (this.state.currentViewIndex === 1) {
-                data = _.sortBy(_.filter(data, function(d)  {
-                    return parseInt(d.healed, 10) > 0;
-                }), function(d)  {
-                    if (this.state.currentViewIndex === 1) {
-                        return -parseInt(d.healed, 10);
+                if (combatant.Job !== "") {
+                    // should probably fix this
+                    if (this.props.currentView === 'Healing') {
+                        if (parseInt(combatant.healed, 10) > 0) {
+                            if (!maxdps) {
+                                maxdps = parseFloat(combatant.healed);
+                            }
+                            stats = {
+                                job: combatant.Job || '',
+                                characterName: combatant.name,
+                                total: combatant.healed,
+                                totalFormatted: formatNumber(combatant.healed),
+                                perSecond: formatNumber(combatant.enchps),
+                                additional: combatant['OverHealPct'],
+                                percentage: combatant['healed%']
+                            };
+                        }
+                    } else if (this.props.currentView === 'Tanking') {
+                        if (parseInt(combatant.damagetaken, 10) > 0) {
+                            if (!maxdps) {
+                                maxdps = parseFloat(combatant.damagetaken);
+                            }
+                            stats = {
+                                job: combatant.Job || '',
+                                characterName: combatant.name,
+                                total: combatant.damagetaken,
+                                totalFormatted: formatNumber(combatant.damagetaken),
+                                perSecond: combatant.ParryPct,
+                                percentage: combatant.BlockPct
+                            };
+                        }
+                    } else {
+                        if (!maxdps) {
+                            maxdps = parseFloat(combatant.damage);
+                        }
+                        stats = {
+                            job: combatant.Job || '',
+                            characterName: combatant.name,
+                            total: combatant.damage,
+                            totalFormatted: formatNumber(combatant.damage),
+                            perSecond: formatNumber(combatant.encdps),
+                            percentage: combatant['damage%']
+                        };
                     }
-                }.bind(this));
-            }
-            // Tanking
-            else if (this.state.currentViewIndex === 2) {
-                data = _.sortBy(_.filter(data, function(d)  {
-                    return parseInt(d.damagetaken, 10) > 0;
-                }), function(d)  {
-                    if (this.state.currentViewIndex === 2) {
-                        return -parseInt(d.damagetaken, 10);
+
+                    if (stats) {
+                        rows.push(React.createElement(CombatantCompact, _extends({
+                            onClick: this.props.onClick,
+                            encounterDamage: this.props.encounterDamage,
+                            rank: rank,
+                            data: combatant,
+                            isSelf: isSelf,
+                            key: combatant.name,
+                            max: maxdps
+                        }, stats)));
+                        rank++;
                     }
-                }.bind(this));
+                }
+            }
+
+            return React.createElement(
+                'ul',
+                { className: 'combatants' },
+                rows
+            );
+        }
+    }]);
+
+    return Combatants;
+}(React.Component);
+
+Combatants.defaultProps = {
+    onClick: function onClick() {}
+};
+
+var DamageMeter = function (_React$Component5) {
+    _inherits(DamageMeter, _React$Component5);
+
+    function DamageMeter(props) {
+        _classCallCheck(this, DamageMeter);
+
+        var _this5 = _possibleConstructorReturn(this, (DamageMeter.__proto__ || Object.getPrototypeOf(DamageMeter)).call(this, props));
+
+        _this5.state = {
+            currentViewIndex: 0
+        };
+        return _this5;
+    }
+
+    _createClass(DamageMeter, [{
+        key: 'shouldComponentUpdate',
+        value: function shouldComponentUpdate(nextProps, nextState) {
+            if (nextProps.parseData.Encounter.encdps === '---') {
+                return false;
+            }
+
+            if (this.state.currentViewIndex !== nextState.currentViewIndex) {
+                return true;
+            }
+
+            if (this.state.selectedEncounter) {
+                return false;
+            }
+
+            return true;
+        }
+    }, {
+        key: 'componentWillReceiveProps',
+        value: function componentWillReceiveProps(nextProps) {
+            // save this encounter data
+            if (this.props.parseData.Encounter.title === 'Encounter' && nextProps.parseData.Encounter.title !== 'Encounter') {
+                EncountersArray.unshift({
+                    Encounter: nextProps.parseData.Encounter,
+                    Combatant: nextProps.parseData.Combatant
+                });
+
+                // Only keep the last 10 fights
+                if (EncountersArray.length > 10) {
+                    EncountersArray.pop();
+                }
             }
         }
+    }, {
+        key: 'handleCombatRowClick',
+        value: function handleCombatRowClick(e) {}
+    }, {
+        key: 'handleClick',
+        value: function handleClick(e) {}
+    }, {
+        key: 'handleViewChange',
+        value: function handleViewChange(e) {
+            var index = this.state.currentViewIndex;
 
-        return (
-            React.createElement("div", {
-                onClick: this.handleClick, 
-                className: 'damage-meter' + (!this.props.parseData.isActive ? ' inactive' : '') + (!this.props.noJobColors ? ' show-job-colors' : '')}, 
+            if (index > this.props.chartViews.length - 2) {
+                index = 0;
+            } else {
+                index++;
+            }
+
+            this.setState({
+                currentViewIndex: index
+            });
+        }
+    }, {
+        key: 'handleSelectEncounter',
+        value: function handleSelectEncounter(index, e) {
+            if (index >= 0) {
+                this.setState({
+                    selectedEncounter: EncountersArray[index]
+                });
+            } else {
+                this.setState({
+                    selectedEncounter: null
+                });
+            }
+            this.render();
+            console.log('handle select', index);
+        }
+    }, {
+        key: 'render',
+        value: function render() {
+            var _this6 = this;
+
+            var debug = false;
+            var data = this.props.parseData.Combatant;
+            var encounterData = this.props.parseData.Encounter;
+
+            if (this.state.selectedEncounter) {
+                data = this.state.selectedEncounter.Combatant;
+                encounterData = this.state.selectedEncounter.Encounter;
+            } else {
+                // Healing
+                // need to resort data if currentView is not damage
+                if (this.state.currentViewIndex === 1) {
+                    data = _.sortBy(_.filter(data, function (d) {
+                        return parseInt(d.healed, 10) > 0;
+                    }), function (d) {
+                        if (_this6.state.currentViewIndex === 1) {
+                            return -parseInt(d.healed, 10);
+                        }
+                    });
+                }
+                // Tanking
+                else if (this.state.currentViewIndex === 2) {
+                        data = _.sortBy(_.filter(data, function (d) {
+                            return parseInt(d.damagetaken, 10) > 0;
+                        }), function (d) {
+                            if (_this6.state.currentViewIndex === 2) {
+                                return -parseInt(d.damagetaken, 10);
+                            }
+                        });
+                    }
+            }
+
+            return React.createElement(
+                'div',
+                {
+                    onClick: this.handleClick,
+                    className: 'damage-meter' + (!this.props.parseData.isActive ? ' inactive' : '') + (!this.props.noJobColors ? ' show-job-colors' : '') },
                 React.createElement(Header, {
-                    encounter: encounterData, 
+                    encounter: encounterData,
                     data: data,
-                    onViewChange: this.handleViewChange.bind(this), 
-                    onSelectEncounter: this.handleSelectEncounter.bind(this), 
-                    currentView: this.props.chartViews[this.state.currentViewIndex]}
-                    ), 
+                    onViewChange: this.handleViewChange.bind(this),
+                    onSelectEncounter: this.handleSelectEncounter.bind(this),
+                    currentView: this.props.chartViews[this.state.currentViewIndex]
+                }),
                 React.createElement(Combatants, {
-                    currentView: this.props.chartViews[this.state.currentViewIndex], 
-                    onClick: this.handleCombatRowClick, 
-                    data: data, 
-                    encounterDamage: encounterData.damage})
-            )
-        );
-    }});
+                    currentView: this.props.chartViews[this.state.currentViewIndex],
+                    onClick: this.handleCombatRowClick,
+                    data: data,
+                    encounterDamage: encounterData.damage }),
+                !debug ? null : React.createElement(
+                    'div',
+                    null,
+                    React.createElement(Debugger, { data: encounterData }),
+                    React.createElement(Debugger, { data: data })
+                )
+            );
+        }
+    }]);
 
+    return DamageMeter;
+}(React.Component);
 
 DamageMeter.defaultProps = {
-    chartViews: [
-        'Damage',
-        'Healing',
-        'Tanking'
-    ],
+    chartViews: ['Damage', 'Healing', 'Tanking'],
     parseData: {},
     noJobColors: false
 };
+
+var Debugger = function (_React$Component6) {
+    _inherits(Debugger, _React$Component6);
+
+    function Debugger(props) {
+        _classCallCheck(this, Debugger);
+
+        return _possibleConstructorReturn(this, (Debugger.__proto__ || Object.getPrototypeOf(Debugger)).call(this, props));
+    }
+
+    _createClass(Debugger, [{
+        key: 'render',
+        value: function render() {
+            var css = {
+                overflowY: 'scroll',
+                maxHeight: '500px'
+            };
+            return React.createElement(
+                'pre',
+                { style: css },
+                JSON.stringify(this.props.data, null, 2)
+            );
+        }
+    }]);
+
+    return Debugger;
+}(React.Component);

--- a/app/rdmty.js
+++ b/app/rdmty.js
@@ -224,24 +224,31 @@ var Header = function (_React$Component3) {
 
             // This is the switcher for Toggling group info or self info
             var DataSource = this.state.group ? encounter : self;
-
+            if (self == undefined) {
+                DataSource = encounter;
+            }
             // Calculate the drect hit % based off of the combatant list. This is not efficient and needs to be removed
             // Once the encounter object is fixed to properly include this info.
             var datalength = 0;
             var DirectHitPct = 0;
             var CritDirectHitPct = 0;
+
             if (this.state.group) {
-                for (var x in data) {
-                    if (!data.hasOwnProperty(x)) continue;
-                    DirectHitPct += parseFloat(data[x].DirectHitPct.substring(0, data[x].DirectHitPct.length - 1));
-                    CritDirectHitPct += parseFloat(data[x].CritDirectHitPct.substring(0, data[x].CritDirectHitPct.length - 1));
-                    datalength++;
+                if (data.length > 0) {
+                    for (var x in data) {
+                        if (!data.hasOwnProperty(x)) continue;
+                        DirectHitPct += parseFloat(data[x].DirectHitPct.substring(0, data[x].DirectHitPct.length - 1));
+                        CritDirectHitPct += parseFloat(data[x].CritDirectHitPct.substring(0, data[x].CritDirectHitPct.length - 1));
+                        datalength++;
+                    }
                 }
                 DirectHitPct = parseFloat(DirectHitPct / datalength);
                 CritDirectHitPct = parseFloat(CritDirectHitPct / datalength);
             } else {
-                DirectHitPct = self.DirectHitPct;
-                CritDirectHitPct = self.CritDirectHitPct;
+                if (self != undefined) {
+                    DirectHitPct = self.DirectHitPct;
+                    CritDirectHitPct = self.CritDirectHitPct;
+                }
             }
 
             return React.createElement(
@@ -294,7 +301,7 @@ var Header = function (_React$Component3) {
                 React.createElement(
                     'div',
                     { className: 'extra-details' },
-                    React.createElement(
+                    this.props.currentView == "Damage" ? React.createElement(
                         'div',
                         { className: 'data-set-view-switcher clearfix', onClick: this.handleToggleStats.bind(this) },
                         React.createElement(
@@ -307,7 +314,7 @@ var Header = function (_React$Component3) {
                             { className: 'data-set-option ' + (!this.state.group ? 'active' : '') },
                             'I'
                         )
-                    ),
+                    ) : null,
                     React.createElement(
                         'div',
                         { className: 'extra-row damage' },
@@ -665,7 +672,7 @@ var DamageMeter = function (_React$Component5) {
         value: function render() {
             var _this6 = this;
 
-            var debug = false;
+            var debug = true;
             var data = this.props.parseData.Combatant;
             var encounterData = this.props.parseData.Encounter;
 
@@ -716,8 +723,7 @@ var DamageMeter = function (_React$Component5) {
                 !debug ? null : React.createElement(
                     'div',
                     null,
-                    React.createElement(Debugger, { data: encounterData }),
-                    React.createElement(Debugger, { data: data })
+                    React.createElement(Debugger, { data: this.props.parseData })
                 )
             );
         }

--- a/app/rdmty.js
+++ b/app/rdmty.js
@@ -672,7 +672,7 @@ var DamageMeter = function (_React$Component5) {
         value: function render() {
             var _this6 = this;
 
-            var debug = true;
+            var debug = false;
             var data = this.props.parseData.Combatant;
             var encounterData = this.props.parseData.Encounter;
 

--- a/app/rdmty.js
+++ b/app/rdmty.js
@@ -232,21 +232,20 @@ var Header = function (_React$Component3) {
             var datalength = 0;
             var DirectHitPct = 0;
             var CritDirectHitPct = 0;
-
             if (this.state.group) {
-                if (data.length > 0) {
+                if (data !== undefined) {
                     for (var x in data) {
                         if (!data.hasOwnProperty(x)) continue;
                         DirectHitPct += parseFloat(data[x].DirectHitPct.substring(0, data[x].DirectHitPct.length - 1));
                         CritDirectHitPct += parseFloat(data[x].CritDirectHitPct.substring(0, data[x].CritDirectHitPct.length - 1));
                         datalength++;
                     }
-                }
-                if (DirectHitPct > 0) {
-                    DirectHitPct = parseFloat(DirectHitPct / datalength);
-                }
-                if (CritDirectHitPct > 0) {
-                    CritDirectHitPct = parseFloat(CritDirectHitPct / datalength);
+                    if (DirectHitPct > 0) {
+                        DirectHitPct = parseFloat(DirectHitPct / datalength);
+                    }
+                    if (CritDirectHitPct > 0) {
+                        CritDirectHitPct = parseFloat(CritDirectHitPct / datalength);
+                    }
                 }
             } else {
                 if (self != undefined) {

--- a/app/rdmty.js
+++ b/app/rdmty.js
@@ -242,8 +242,12 @@ var Header = function (_React$Component3) {
                         datalength++;
                     }
                 }
-                DirectHitPct = parseFloat(DirectHitPct / datalength);
-                CritDirectHitPct = parseFloat(CritDirectHitPct / datalength);
+                if (DirectHitPct > 0) {
+                    DirectHitPct = parseFloat(DirectHitPct / datalength);
+                }
+                if (CritDirectHitPct > 0) {
+                    CritDirectHitPct = parseFloat(CritDirectHitPct / datalength);
+                }
             } else {
                 if (self != undefined) {
                     DirectHitPct = self.DirectHitPct;

--- a/app/rdmty.js
+++ b/app/rdmty.js
@@ -160,6 +160,7 @@ var Header = function (_React$Component3) {
 
         _this3.state = {
             expanded: false,
+            group: true,
             showEncountersList: false
         };
         return _this3;
@@ -196,33 +197,52 @@ var Header = function (_React$Component3) {
                 showEncountersList: !this.state.showEncountersList
             });
         }
+
+        /**
+         * Toggle between group and indidivual stats.
+         */
+
+    }, {
+        key: 'handleToggleStats',
+        value: function handleToggleStats(e) {
+            this.setState({
+                group: !this.state.group
+            });
+        }
     }, {
         key: 'render',
         value: function render() {
+            var data = this.props.data;
             var encounter = this.props.encounter;
+            var self = data['YOU'];
+
             var rdps = parseFloat(encounter.encdps);
             var rdps_max = 0;
-
             if (!isNaN(rdps) && rdps !== Infinity) {
                 rdps_max = Math.max(rdps_max, rdps);
             }
 
+            // This is the switcher for Toggling group info or self info
+            var DataSource = this.state.group ? encounter : self;
+
             // Calculate the drect hit % based off of the combatant list. This is not efficient and needs to be removed
             // Once the encounter object is fixed to properly include this info.
-            var data = this.props.data;
             var datalength = 0;
             var DirectHitPct = 0;
             var CritDirectHitPct = 0;
-
-            for (var x in data) {
-                if (!data.hasOwnProperty(x)) continue;
-                DirectHitPct += parseFloat(data[x].DirectHitPct.substring(0, data[x].DirectHitPct.length - 1));
-                CritDirectHitPct += parseFloat(data[x].CritDirectHitPct.substring(0, data[x].CritDirectHitPct.length - 1));
-                datalength++;
+            if (this.state.group) {
+                for (var x in data) {
+                    if (!data.hasOwnProperty(x)) continue;
+                    DirectHitPct += parseFloat(data[x].DirectHitPct.substring(0, data[x].DirectHitPct.length - 1));
+                    CritDirectHitPct += parseFloat(data[x].CritDirectHitPct.substring(0, data[x].CritDirectHitPct.length - 1));
+                    datalength++;
+                }
+                DirectHitPct = parseFloat(DirectHitPct / datalength);
+                CritDirectHitPct = parseFloat(CritDirectHitPct / datalength);
+            } else {
+                DirectHitPct = self.DirectHitPct;
+                CritDirectHitPct = self.CritDirectHitPct;
             }
-
-            DirectHitPct = parseFloat(DirectHitPct / datalength);
-            CritDirectHitPct = parseFloat(CritDirectHitPct / datalength);
 
             return React.createElement(
                 'div',
@@ -276,6 +296,20 @@ var Header = function (_React$Component3) {
                     { className: 'extra-details' },
                     React.createElement(
                         'div',
+                        { className: 'data-set-view-switcher clearfix', onClick: this.handleToggleStats.bind(this) },
+                        React.createElement(
+                            'span',
+                            { className: 'data-set-option ' + (this.state.group ? 'active' : '') },
+                            'G'
+                        ),
+                        React.createElement(
+                            'span',
+                            { className: 'data-set-option ' + (!this.state.group ? 'active' : '') },
+                            'I'
+                        )
+                    ),
+                    React.createElement(
+                        'div',
                         { className: 'extra-row damage' },
                         React.createElement(
                             'div',
@@ -288,7 +322,7 @@ var Header = function (_React$Component3) {
                             React.createElement(
                                 'span',
                                 { className: 'value ff-text' },
-                                formatNumber(encounter.damage) + ' (' + formatNumber(encounter.encdps) + ')'
+                                formatNumber(DataSource.damage) + ' (' + formatNumber(DataSource.encdps) + ')'
                             )
                         ),
                         React.createElement(
@@ -302,7 +336,7 @@ var Header = function (_React$Component3) {
                             React.createElement(
                                 'span',
                                 { className: 'value ff-text' },
-                                encounter.maxhit
+                                DataSource.maxhit
                             )
                         )
                     ),
@@ -320,7 +354,7 @@ var Header = function (_React$Component3) {
                             React.createElement(
                                 'span',
                                 { className: 'value ff-text' },
-                                formatNumber(parseFloat(encounter.crithits / encounter.hits * 100)) + "%"
+                                formatNumber(parseFloat(DataSource.crithits / DataSource.hits * 100)) + "%"
                             )
                         ),
                         React.createElement(
@@ -380,7 +414,21 @@ var Header = function (_React$Component3) {
                             React.createElement(
                                 'span',
                                 { className: 'value ff-text' },
-                                formatNumber(encounter.healed) + ' (' + formatNumber(encounter.enchps) + ')'
+                                formatNumber(DataSource.healed) + ' (' + formatNumber(DataSource.enchps) + ')'
+                            )
+                        ),
+                        React.createElement(
+                            'div',
+                            { className: 'cell' },
+                            React.createElement(
+                                'span',
+                                { className: 'label ff-header' },
+                                'Crit%'
+                            ),
+                            React.createElement(
+                                'span',
+                                { className: 'value ff-text' },
+                                DataSource['critheal%']
                             )
                         ),
                         React.createElement(
@@ -394,7 +442,7 @@ var Header = function (_React$Component3) {
                             React.createElement(
                                 'span',
                                 { className: 'value ff-text' },
-                                encounter.maxheal
+                                DataSource.maxheal
                             )
                         )
                     )
@@ -698,7 +746,7 @@ var Debugger = function (_React$Component6) {
         value: function render() {
             var css = {
                 overflowY: 'scroll',
-                maxHeight: '500px'
+                maxHeight: '250px'
             };
             return React.createElement(
                 'pre',

--- a/app/rdmty.jsx
+++ b/app/rdmty.jsx
@@ -171,8 +171,12 @@ class Header extends React.Component {
               datalength++;
             }
           }
-          DirectHitPct = parseFloat( DirectHitPct / datalength);
-          CritDirectHitPct = parseFloat( CritDirectHitPct / datalength);
+          if ( DirectHitPct > 0 ){
+              DirectHitPct = parseFloat( DirectHitPct / datalength);
+          }
+          if (CritDirectHitPct > 0){
+            CritDirectHitPct = parseFloat( CritDirectHitPct / datalength);
+          }
         } else {
           if (self != undefined){
             DirectHitPct = self.DirectHitPct;

--- a/app/rdmty.jsx
+++ b/app/rdmty.jsx
@@ -161,21 +161,20 @@ class Header extends React.Component {
         var datalength = 0;
         var DirectHitPct = 0
         var CritDirectHitPct = 0;
-
         if (this.state.group){
-          if (data.length > 0){
+          if (data !== undefined){
             for (var x in data){
               if(!data.hasOwnProperty(x)) continue;
               DirectHitPct += parseFloat(data[x].DirectHitPct.substring(0, (data[x].DirectHitPct.length - 1)));
               CritDirectHitPct += parseFloat(data[x].CritDirectHitPct.substring(0, (data[x].CritDirectHitPct.length - 1)));
               datalength++;
             }
-          }
-          if ( DirectHitPct > 0 ){
-              DirectHitPct = parseFloat( DirectHitPct / datalength);
-          }
-          if (CritDirectHitPct > 0){
-            CritDirectHitPct = parseFloat( CritDirectHitPct / datalength);
+            if ( DirectHitPct > 0 ){
+                DirectHitPct = parseFloat( DirectHitPct / datalength);
+            }
+            if (CritDirectHitPct > 0){
+              CritDirectHitPct = parseFloat( CritDirectHitPct / datalength);
+            }
           }
         } else {
           if (self != undefined){

--- a/app/rdmty.jsx
+++ b/app/rdmty.jsx
@@ -480,7 +480,7 @@ class DamageMeter extends React.Component {
     }
 
     render() {
-        const debug = true;
+        const debug = false;
         var data = this.props.parseData.Combatant;
         var encounterData = this.props.parseData.Encounter;
 

--- a/app/rdmty.jsx
+++ b/app/rdmty.jsx
@@ -153,24 +153,31 @@ class Header extends React.Component {
 
         // This is the switcher for Toggling group info or self info
         var DataSource = this.state.group ? encounter : self;
-
+        if (self == undefined){
+          DataSource = encounter;
+        }
         // Calculate the drect hit % based off of the combatant list. This is not efficient and needs to be removed
         // Once the encounter object is fixed to properly include this info.
         var datalength = 0;
         var DirectHitPct = 0
         var CritDirectHitPct = 0;
+
         if (this.state.group){
-          for (var x in data){
-            if(!data.hasOwnProperty(x)) continue;
-            DirectHitPct += parseFloat(data[x].DirectHitPct.substring(0, (data[x].DirectHitPct.length - 1)));
-            CritDirectHitPct += parseFloat(data[x].CritDirectHitPct.substring(0, (data[x].CritDirectHitPct.length - 1)));
-            datalength++;
+          if (data.length > 0){
+            for (var x in data){
+              if(!data.hasOwnProperty(x)) continue;
+              DirectHitPct += parseFloat(data[x].DirectHitPct.substring(0, (data[x].DirectHitPct.length - 1)));
+              CritDirectHitPct += parseFloat(data[x].CritDirectHitPct.substring(0, (data[x].CritDirectHitPct.length - 1)));
+              datalength++;
+            }
           }
           DirectHitPct = parseFloat( DirectHitPct / datalength);
           CritDirectHitPct = parseFloat( CritDirectHitPct / datalength);
         } else {
-          DirectHitPct = self.DirectHitPct;
-          CritDirectHitPct = self.CritDirectHitPct;
+          if (self != undefined){
+            DirectHitPct = self.DirectHitPct;
+            CritDirectHitPct = self.CritDirectHitPct;
+          }
         }
 
         return (
@@ -204,12 +211,12 @@ class Header extends React.Component {
                     </div>
                 </div>
                 <div className="extra-details">
-
-                    <div className="data-set-view-switcher clearfix" onClick={this.handleToggleStats.bind(this)}>
-                      <span className={`data-set-option ${this.state.group ? 'active' : ''}`}>G</span>
-                      <span className={`data-set-option ${!this.state.group ? 'active' : ''}`}>I</span>
-                    </div>
-
+                    {this.props.currentView == "Damage" ?
+                      <div className="data-set-view-switcher clearfix" onClick={this.handleToggleStats.bind(this)}>
+                        <span className={`data-set-option ${this.state.group ? 'active' : ''}`}>G</span>
+                        <span className={`data-set-option ${!this.state.group ? 'active' : ''}`}>I</span>
+                      </div>
+                    : null}
                     <div className="extra-row damage">
                         <div className="cell">
                             <span className="label ff-header">Damage</span>
@@ -473,7 +480,7 @@ class DamageMeter extends React.Component {
     }
 
     render() {
-        const debug = false;
+        const debug = true;
         var data = this.props.parseData.Combatant;
         var encounterData = this.props.parseData.Encounter;
 
@@ -524,8 +531,7 @@ class DamageMeter extends React.Component {
                 {
                   !debug ? null :
                   <div>
-                    <Debugger data={encounterData}/>
-                    <Debugger data={data}/>
+                    <Debugger data={this.props.parseData}/>
                   </div>
                 }
             </div>

--- a/css/rdmty.css
+++ b/css/rdmty.css
@@ -113,6 +113,31 @@ ul {
     text-shadow: 0 -1px 1px #2361a4;
 }
 
+.data-set-view-switcher{
+  float:right;
+  background:rgba(0,0,0,.35);
+}
+.data-set-option{
+  display: inline-block;
+  border-radius: 2px;
+  cursor: pointer;
+  padding: 2px 8px;
+  text-align: center;
+  //width: 50px;
+  color: #eee;
+  font-size: 10px;
+  font-weight: normal;
+}
+.data-set-option.active{
+  background-color: #2a81d7;
+  box-shadow: inset 0 1px 0 0 #62b1e9;
+  border-top: 1px solid #2a73a6;
+  border-right: 1px solid #165899;
+  border-bottom: 1px solid #07428f;
+  border-left: 1px solid #165899;
+  text-shadow: 0 -1px 1px #1d62ab;
+}
+
 .target-name {
     cursor: pointer;
     font-weight: 400;
@@ -312,4 +337,13 @@ li:last-child {
     left: 0px;
     padding: 2px 4px;
     z-index: 100;
+}
+
+.clearfix:before,
+.clearfix:after{
+  display:table;
+  content:'';
+}
+.clearfix:after{
+  clear:both;
 }


### PR DESCRIPTION
I updated the header data to show Group (G) or Individual (I) stats. this option is only avialable in the damage chart because the other two datasets don't send over the combatant lists. 

The header will default to group automatically if you switch to those pages. 

I also added in the toggle button in the header area once expanded. 

Also found several bugs in rainbow mage overlay plugin and noted teh problems via comments through teh code. 